### PR TITLE
Fix apt-get command in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ Some specific examples may require other tools including:
 
 * http://www.boost.org/[boost]
 
-  $ sudo apt-get libboost-all-dev
+  $ sudo apt-get install libboost-all-dev
 
 * https://github.com/google/protobuf[protobuf]
 


### PR DESCRIPTION
Simple change. But I just noticed it.

I have a bad habit of just copying and pasting random commands. So I was surprised my terminal gave me an error