### PR TITLE
Updated README.adoc's Docker instructions.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,8 +80,9 @@ To build the full set of cmake-examples test cases you can run:
 [source,bash]
 ----
 docker run -it matrim/cmake-examples:3.5.1
-git clone https://github.com/ttroy50/cmake-examples.git
-cd cmake-examples
+cd ~ 
+git clone https://github.com/ttroy50/cmake-examples.git code
+cd code
 ./test.sh
 ----
 


### PR DESCRIPTION
Here's a comparison between using the original Docker commands (left terminal) and the updated ones (right):

<img width="889" alt="image" src="https://user-images.githubusercontent.com/37529096/70959735-ddd9f280-20e1-11ea-96cd-0ca7af5811e6.png">

Essentially if I don't name the repo `code` in Docker (like how you're doing it in your travis build), it'll get stuck on `Checking clang-format changes` like in the left image.