### PR TITLE
fix: fix CMakeLists.txt in chapter H

### DIFF
--- a/01-basic/H-third-party-library/CMakeLists.txt
+++ b/01-basic/H-third-party-library/CMakeLists.txt
@@ -17,8 +17,14 @@ endif()
 # Add an executable
 add_executable(third_party_include main.cpp)
 
+# Include the boost headers
+target_include_directories( third_party_include
+    PRIVATE ${Boost_INCLUDE_DIRS}
+)
+
 # link against the boost libraries
 target_link_libraries( third_party_include
     PRIVATE
-        Boost::filesystem
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
 )


### PR DESCRIPTION
First of all, thank you for this helpful tutorial.

In my understanding, the intent of chapter H was to show linking using Non-alias targets. Imported alias targets was rather used in chapter K, so it seems the content is duplicated.