### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ cd code
 ./test.sh
 ----
 
-For more details on build and running the docker containers link:here[dockerfiles].
+For more details on build and running the docker containers link: https://docs.docker.com/engine/reference/commandline/build/[dockerfiles].
 
 # Other Links
 
@@ -94,15 +94,15 @@ There are many CMake tutorials and examples online. The list below includes link
 to some of these which I have found helpful in my CMake journey.
 
   * https://web.archive.org/web/20160314094326/https://www.kdab.com/~stephen/moderncmake.pdf[Modern CMake Slides]
-  * https://rix0r.nl/blog/2015/08/13/cmake-guide/[rix0r Modern CMake Blog]
-  * https://cmake.org/cmake-tutorial/[Official CMake Tutorial]
+ 
+  * https://cmake.org/cmake/help/latest/guide/tutorial/index.html[Official CMake Tutorial]
   * https://gitlab.kitware.com/cmake/community/wikis/home[Official CMake Wiki]
   * https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/Useful-Variables[CMake Useful Variables]
   * http://derekmolloy.ie/hello-world-introductions-to-cmake/[Derek Molloy - Intro to CMake]
-  * http://techminded.net/blog/modular-c-projects-with-cmake.html[Modular C++ Projects]
+
   * https://web.archive.org/web/20190320121339/http://voices.canonical.com/jussi.pakkanen/2013/03/26/a-list-of-common-cmake-antipatterns/[Common CMake Anti-Patterns]
   * http://baptiste-wicht.com/posts/2014/04/install-use-clang-static-analyzer-cmake.html[Using clang static analyser with CMake]
   * https://cmake.org/pipermail/cmake/2011-April/043709.html[Static Analysis with CDash] - Includes some info about using CppCheck with CMake
   * https://samthursfield.wordpress.com/2015/10/20/some-cmake-tips/[CMake Tips]
-  * https://www.johnlamp.net/cmake-tutorial.html[John Lamp - CMake Tutorial]
+
   * link:https://docs.conan.io[Conan Documentation]


### PR DESCRIPTION
Hi there!  I edited few issues I ran into with some of the resource links. I removed the ones with 404 errors, added a direct link to the new CMake tutorial page (they moved there page). Lastly is one I am unsure about which is the "dockerfiles" link. The link went nowhere so I added the link to the official docker build site. I am not sure if that was the intended destination. Cheers.

Details:
Adjustments to DOCKER section
- Added link on line 89 to more docker details (Not sure if this was the intended resource)-> https://docs.docker.com/engine/reference/commandline/build/  

Adjustments to OTHER LINKS section.
- Removed line 97 " * https://rix0r.nl/blog/2015/08/13/cmake-guide/[rix0r Modern CMake Blog]" https certifcate cannot be verified.
- Fixed link on line 98 -> Offiicial CMake Turtorial 
- Removed line 102 " * http://techminded.net/blog/modular-c-projects-with-cmake.html[Modular C++ Projects]" -> No longer exists responds with 404 Error
- Removed line 107 "  * https://www.johnlamp.net/cmake-tutorial.html[John Lamp - CMake Tutorial]" -> No longer exists responds with 404 Error